### PR TITLE
Improve using one channel only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## Changelog
+
+### v0.1.2
+- Improve `concurrent.Execute` to just use 1 input channel and 1 output channel for all goroutines
+
+### v0.1.1
+- Fix documentation
+
+### v0.1.0
+- Execute a function concurrently for a set of inputs: `concurrent.Execute`

--- a/README.md
+++ b/README.md
@@ -4,10 +4,46 @@ Go concurrency generics
 ## Documentation
 https://pkg.go.dev/github.com/raymondhartoyo/gorutin
 
+## Usage
+
+### Processing a set of inputs concurrently
+
+Given a set of inputs and a function to be run concurrently, you can call `concurrent.Execute` as shown in the following example:
+
+```
+inputs := []string{
+	"Alice",
+	"Bob",
+	"John",
+	"Doe",
+	"Sarah",
+	"Susan",
+}
+
+process := func(input string) string {
+	return fmt.Sprintf("Hi %s", input)
+}
+
+outputs := concurrent.Execute(4, inputs, process)
+sort.Strings(outputs)
+for _, output := range outputs {
+	fmt.Println(output)
+}
+
+// Output:
+// Hi Alice
+// Hi Bob
+// Hi Doe
+// Hi John
+// Hi Sarah
+// Hi Susan
+```
+
 ## Release Information
 
-### v0.1.1
-This is still an unstable release, public APIs (function signatures might be updated at the future release).
+### v0.1
+- This is still an unstable release, public APIs (function signatures might be updated at the future release).
+- See [CHANGELOG.md](CHANGELOG.md)
 
 ## Future milestones
 - Context cancellation

--- a/concurrent/concurrent.go
+++ b/concurrent/concurrent.go
@@ -15,12 +15,12 @@ func Execute[TypeIn any, TypeOut any](numOfRoutines int, inputs []TypeIn, proces
 	// spawn workers
 	for i := 0; i < numOfRoutines; i++ {
 		wg.Add(1)
-		go func(inputChan chan TypeIn, outputChan chan TypeOut) {
+		go func() {
 			defer wg.Done()
-			for input := range inputChan {
-				outputChan <- process(input)
+			for input := range inputChannel {
+				outputChannel <- process(input)
 			}
-		}(inputChannel, outputChannel)
+		}()
 	}
 	go func() {
 		wg.Wait()
@@ -28,12 +28,12 @@ func Execute[TypeIn any, TypeOut any](numOfRoutines int, inputs []TypeIn, proces
 	}()
 
 	// distribute inputs
-	go func(inputs []TypeIn, inputChannels chan TypeIn) {
+	go func() {
 		for _, input := range inputs {
 			inputChannel <- input
 		}
 		close(inputChannel)
-	}(inputs, inputChannel)
+	}()
 
 	// wait for outputs
 	outputs := []TypeOut{}


### PR DESCRIPTION
`concurrent.Execute` is simplified to just use 1 channel for input and 1 channel for output for all goroutines.

Also adding usage example in README.